### PR TITLE
add update sensor name field to manage endpoint

### DIFF
--- a/app/scripts/templates/edit.ejs
+++ b/app/scripts/templates/edit.ejs
@@ -19,6 +19,10 @@
           <input type="text" name="longitude" placeholder="0.0" id="longitude">
         </div>
         <div class="form-group">
+          <label for="sensor_name">Sensor Name</label>
+          <input type="text" name="sensor_name" placeholder="Enter the name of your device" id="sensor_name">
+        </div>
+        <div class="form-group">
           <label for="description">Description</label>
           <input type="text" name="description" placeholder="Enter a description of your device" id="description">
         </div>

--- a/app/scripts/views/edit.js
+++ b/app/scripts/views/edit.js
@@ -35,7 +35,7 @@ Air.Views = Air.Views || {};
       }.bind(this));
 
       // Cache id fields
-      this.fields = ['longitude', 'latitude', 'description', 'email', 'arduino'];
+      this.fields = ['longitude', 'latitude', 'sensor_name', 'description', 'email', 'arduino'];
       this.fields.forEach(function(field) {
         this['$' + field] = this.$('input[name="' + field + '"]');
       }.bind(this));


### PR DESCRIPTION
This adds an extra field for the `sensor_name`. Enables someone to update the auto-generated name to be whatever they choose. This name is then put at the top of the report view. 

cc @WillieShubert 
